### PR TITLE
Fix spiff access in spotify

### DIFF
--- a/components/GlobalInit/GlobalInit.c
+++ b/components/GlobalInit/GlobalInit.c
@@ -8,7 +8,6 @@ SemaphoreHandle_t FinishWifiConfig = NULL;
 #ifdef SpotifyEnable
 SemaphoreHandle_t WifiParamExistenceCheckerSemaphore = NULL;
 SemaphoreHandle_t IsSpotifyAuthorizedSemaphore = NULL;
-SemaphoreHandle_t WorkWithStorageInSpotifyComponentSemaphore = NULL;
 
 #endif
 /**
@@ -21,7 +20,6 @@ void GlobalInit()
     BufQueue1 = xQueueCreate(1, sizeof(char) * sizeof(char[2500]));
     FinishWifiConfig = xSemaphoreCreateBinary();
     WifiParamExistenceCheckerSemaphore = xSemaphoreCreateBinary();
-    WorkWithStorageInSpotifyComponentSemaphore = xSemaphoreCreateBinary();
 #ifdef SpotifyEnable
     IsSpotifyAuthorizedSemaphore = xSemaphoreCreateBinary();
 #endif

--- a/components/GlobalInit/GlobalInit.c
+++ b/components/GlobalInit/GlobalInit.c
@@ -2,7 +2,6 @@
 
 static const char *TAG = "Global init";
 extern QueueHandle_t BufQueue1;
-extern SemaphoreHandle_t HttpsResponseReadySemaphore;
 SemaphoreHandle_t FinishWifiConfig = NULL;
 
 #ifdef SpotifyEnable
@@ -16,7 +15,6 @@ SemaphoreHandle_t IsSpotifyAuthorizedSemaphore = NULL;
  */
 void GlobalInit()
 {
-    HttpsResponseReadySemaphore = xSemaphoreCreateBinary();
     BufQueue1 = xQueueCreate(1, sizeof(char) * sizeof(char[2500]));
     FinishWifiConfig = xSemaphoreCreateBinary();
     WifiParamExistenceCheckerSemaphore = xSemaphoreCreateBinary();

--- a/components/GlobalInit/include/GlobalInit.h
+++ b/components/GlobalInit/include/GlobalInit.h
@@ -41,7 +41,6 @@ extern SemaphoreHandle_t FinishWifiConfig;
 
 #ifdef SpotifyEnable
 extern SemaphoreHandle_t IsSpotifyAuthorizedSemaphore;
-extern SemaphoreHandle_t WorkWithStorageInSpotifyComponentSemaphore ;
 /**
  * timeout definition part 
 */

--- a/components/SpotifyInterface/README.md
+++ b/components/SpotifyInterface/README.md
@@ -76,7 +76,6 @@ SpotifyInterfaceHandler_t SpotifyInterfaceHandler;
 
 ```c
 SpotifyInterfaceHandler.HttpsBufQueue = QueueSharedWithHttpsModule;
-SpotifyInterfaceHandler.HttpsResponseReadySemaphore = SemaphoreSharedWithHttpsModule;
 SpotifyInterfaceHandler.ConfigAddressInSpiffs = SpotifyConfigAddressInSpiffs;
 SpotifyInterfaceHandler.ReadTxtFileFromSpiffs = &SpiffsWritefunction;
 SpotifyInterfaceHandler.WriteTxtFileToSpiffs = &SpiffsReadfunction;

--- a/components/SpotifyInterface/SpotifyInterface.c
+++ b/components/SpotifyInterface/SpotifyInterface.c
@@ -10,7 +10,6 @@
 // ****************************** Global Variables
 SpotifyInterfaceHandler_t *InterfaceHandler;
 SpotifyPrivateHandler_t PrivateHandler;
-bool SaveExistence = 0;
 
 // ****************************** Local Variables
 static const char *TAG = "SpotifyTask";
@@ -21,15 +20,6 @@ static bool Spotify_TokenRenew(void);
 static bool Spotify_IsTokenExpired();
 bool Spotify_ExtractAccessToken(char *ReceivedData, size_t SizeOfReceivedData);
 
-// ******************************
-void Spotify_CheckRefreshTokenExistence()
-{
-    if (xSemaphoreTake(*(InterfaceHandler->WorkWithStorageInSpotifyComponentSemaphore), 1) == pdTRUE)
-    {
-        PrivateHandler.Status = EXPIRED;
-        SaveExistence = true;
-    }
-}
 
 /**
  * @brief This function initiates the Spotify authorization process.
@@ -40,7 +30,6 @@ bool Spotify_TaskInit(SpotifyInterfaceHandler_t *SpotifyInterfaceHandler)
 {
     InterfaceHandler = SpotifyInterfaceHandler;
     PrivateHandler.Status = INIT;
-    Spotify_CheckRefreshTokenExistence();
     if (InterfaceHandler->ConfigAddressInSpiffs != NULL &&
         InterfaceHandler->HttpsResponseReadySemaphore != NULL &&
         InterfaceHandler->IsSpotifyAuthorizedSemaphore != NULL &&
@@ -117,7 +106,16 @@ static void Spotify_MainTask(void *pvparameters)
             {
                 if (Spotify_HttpServerServiceInit() == true)                                                        // Init the webserver in initialization
                 {
-                    PrivateHandler.Status = LOGIN;                                                                   // if webserver and mDNS run successfully, go to LOGIN
+                    if (SpiffsExistenceCheck(InterfaceHandler->ConfigAddressInSpiffs) == true)                      // Check if the refresh token exists in the spiffs
+                    {
+                        ESP_LOGI(TAG, "RefreshToken found");
+                        PrivateHandler.Status = EXPIRED;                                                            // If the refresh token exists, set the status to EXPIRED
+                    }
+                    else
+                    {
+                        ESP_LOGW(TAG, "RefreshToken not found!");
+                        PrivateHandler.Status = LOGIN;                                                              // If the refresh token does not exist, set the status to LOGIN 
+                    }
                 }
                 else
                 {
@@ -154,7 +152,7 @@ static void Spotify_MainTask(void *pvparameters)
                 }
                 else
                 {
-                    PrivateHandler.Status = LOGIN;
+                    PrivateHandler.Status = LOGIN;                                                                  // if the response did not come within the expected time, set Status back to LOGIN
                     ESP_LOGW(TAG, "Timeout - Spotify did not respond within the expected time.!");
                 }
                 break;
@@ -162,35 +160,27 @@ static void Spotify_MainTask(void *pvparameters)
             case AUTHORIZED:
             {
                 ESP_LOGI(TAG, "AUTHORIZED");
-                xSemaphoreGive((*InterfaceHandler->IsSpotifyAuthorizedSemaphore));                                  // give IsSpotifyAuthorizedSemaphore semaphore in the inteface handler
                                                                                                                     // so applicaiton can know the Spotify Module is authorized 
                                                                                                                     // and ready for sending commands 
-                if (SaveExistence != 1)
-                {
-                    PrivateHandler.Status = SAVE_NEW_TOKEN;
-                }
-                else
-                {
-                    PrivateHandler.Status = CHECK_TIME;
-                }
+                SpiffsRemoveFile(InterfaceHandler->ConfigAddressInSpiffs);                                          // Delete old value at the directory
+                SaveFileInSpiffsWithTxtFormat(InterfaceHandler->ConfigAddressInSpiffs,                              // Save new file in the directory
+                                              "refresh_token", PrivateHandler.token.RefreshToken, 
+                                              NULL, NULL);
+                PrivateHandler.Status = CHECK_TIME;                                                                 // set Status to CHECK_TIME     
                 break;
             }
             case CHECK_TIME:
             {
-                if (Spotify_IsTokenExpired() == true)                                                                 // Check if the expiration time has elapsed since the last received token
+                xSemaphoreGive((*InterfaceHandler->IsSpotifyAuthorizedSemaphore));                                  // give IsSpotifyAuthorizedSemaphore semaphore in the IntefaceHandler
+
+                if (Spotify_IsTokenExpired() == true)                                                               // Check if the expiration time has elapsed since the last received token
                 {
-                    PrivateHandler.Status = EXPIRED;
+                    PrivateHandler.Status = EXPIRED;                                                                // set Status to EXPIRED if token expired
                 }            
                 break;
             }
             case SAVE_NEW_TOKEN:
             {
-                ESP_LOGI(TAG, "SAVE_NEW_TOKEN");
-                SpiffsRemoveFile(InterfaceHandler->ConfigAddressInSpiffs);                                          // Delete old value at the directory
-                SaveFileInSpiffsWithTxtFormat(InterfaceHandler->ConfigAddressInSpiffs,                              // Save new file in the directory
-                                            "refresh_token", PrivateHandler.token.RefreshToken, 
-                                            NULL, NULL);
-                PrivateHandler.Status = CHECK_TIME;                                                                 // Set back the Status to the CHECK_TIME
                 break;
             }
             case EXPIRED:
@@ -198,7 +188,7 @@ static void Spotify_MainTask(void *pvparameters)
                 ESP_LOGW(TAG, "token is expired");
                 if (Spotify_TokenRenew() == true)                                                                   // Run function to renew the token
                 {
-                    PrivateHandler.Status = AUTHORIZED;                                                             // set Status to AUTHORIZED if token renewed successfully
+                    PrivateHandler.Status = CHECK_TIME;                                                             // set Status to CHECK_TIME if token renewed successfully
                 }
                 else
                 {
@@ -218,11 +208,11 @@ static void Spotify_MainTask(void *pvparameters)
 static bool Spotify_IsTokenExpired()
 {
     bool tokenExpired = false;
-    uint32_t elapsedTime = (xTaskGetTickCount() - PrivateHandler.TokenLastUpdate) * portTICK_PERIOD_MS;
-    elapsedTime = elapsedTime / 1000;
+    uint32_t elapsedTime = (xTaskGetTickCount() - PrivateHandler.TokenLastUpdate) * portTICK_PERIOD_MS;             // Calculate the elapsed time since the last token was received
+    elapsedTime = elapsedTime / 1000;                                                                               // Convert the elapsed time to seconds                                             
     if (elapsedTime > (HOUR - 300))
     {
-        tokenExpired = true;
+        tokenExpired = true;                                                                                        // If the elapsed time is greater than the expiration time, set tokenExpired to true
     }
     return tokenExpired;
 }
@@ -238,8 +228,8 @@ static bool Spotify_TokenRenew(void)
     ESP_LOGI(TAG, "RefreshToken=%s", receivedData);
     SendRequest_ExchangeTokenWithRefreshToken(receivedData);
     memset(receivedData, 0x0, LONG_BUF);
-
-    if (xQueueReceive(httpToSpotifyDataQueue, receivedData, pdMS_TO_TICKS(SEC)) == pdTRUE)
+    
+    if (xQueueReceive(httpToSpotifyDataQueue, receivedData, pdMS_TO_TICKS(SEC)) == pdTRUE) 
     {
         if (Spotify_ExtractAccessToken(receivedData, sizeof(receivedData)) == true)
         {

--- a/components/SpotifyInterface/SpotifyInterface.c
+++ b/components/SpotifyInterface/SpotifyInterface.c
@@ -177,10 +177,6 @@ static void Spotify_MainTask(void *pvparameters)
                 }            
                 break;
             }
-            case SAVE_NEW_TOKEN:
-            {
-                break;
-            }
             case EXPIRED:
             {
                 ESP_LOGW(TAG, "token is expired");

--- a/components/SpotifyInterface/SpotifyInterface.c
+++ b/components/SpotifyInterface/SpotifyInterface.c
@@ -31,7 +31,6 @@ bool Spotify_TaskInit(SpotifyInterfaceHandler_t *SpotifyInterfaceHandler)
     InterfaceHandler = SpotifyInterfaceHandler;
     PrivateHandler.Status = INIT;
     if (InterfaceHandler->ConfigAddressInSpiffs != NULL &&
-        InterfaceHandler->HttpsResponseReadySemaphore != NULL &&
         InterfaceHandler->IsSpotifyAuthorizedSemaphore != NULL &&
         InterfaceHandler->HttpsBufQueue != NULL)
     {

--- a/components/SpotifyInterface/include/SpotifyInterface.h
+++ b/components/SpotifyInterface/include/SpotifyInterface.h
@@ -42,7 +42,6 @@ typedef enum
 typedef struct
 {
     QueueHandle_t *HttpsBufQueue;
-    SemaphoreHandle_t *HttpsResponseReadySemaphore;
     SemaphoreHandle_t *IsSpotifyAuthorizedSemaphore;
     char *ConfigAddressInSpiffs;
 } SpotifyInterfaceHandler_t;

--- a/components/SpotifyInterface/include/SpotifyInterface.h
+++ b/components/SpotifyInterface/include/SpotifyInterface.h
@@ -44,7 +44,6 @@ typedef struct
     QueueHandle_t *HttpsBufQueue;
     SemaphoreHandle_t *HttpsResponseReadySemaphore;
     SemaphoreHandle_t *IsSpotifyAuthorizedSemaphore;
-    SemaphoreHandle_t *WorkWithStorageInSpotifyComponentSemaphore;
     char *ConfigAddressInSpiffs;
 } SpotifyInterfaceHandler_t;
 

--- a/components/SpotifyInterface/lib/SpotifyTypedef.h
+++ b/components/SpotifyInterface/lib/SpotifyTypedef.h
@@ -49,9 +49,8 @@ extern "C"
 #define LOGIN                           1 
 #define AUTHENTICATED                   2
 #define AUTHORIZED                      3
-#define SAVE_NEW_TOKEN                  4
-#define EXPIRED                         5
-#define CHECK_TIME                      6
+#define EXPIRED                         4
+#define CHECK_TIME                      5
 
 typedef struct Token_t
 {
@@ -80,9 +79,8 @@ typedef enum
     LOGIN_USER = 1,
     AUTHENTICATED_USER = 2,
     AUTHORIZED_USER = 3,
-    SAVE_NEW_TOKEN_USER = 4 ,
-    EXPIRED_USER = 5,
-    CHECK_TIME_USER = 6
+    EXPIRED_USER = 4,
+    CHECK_TIME_USER = 5
 } Status_t;
 
 typedef void (*EventHandlerCallBackPtr)(char *Buffer);

--- a/components/nvsFlash/SpiffsManger.c
+++ b/components/nvsFlash/SpiffsManger.c
@@ -93,19 +93,19 @@ void SpiffsInit()
  */
 bool SpiffsExistenceCheck(char *addressInSpiffs)
 {
+    bool retValue;
     FILE *file;
     file = fopen(addressInSpiffs, "r");
     if (file)
     {
-        // ESP_LOGI(TAG, "File exists.");
-        fclose(file);
-        return true;
+        retValue = true;
     }
     else
     {
-        // ESP_LOGI(TAG, "File does not exist.");
-        return false;
+        retValue = false;
     }
+    fclose(file);
+    return retValue;
 }
 /**
  *@brief Write data to a new file or append to existing file
@@ -114,7 +114,7 @@ bool SpiffsExistenceCheck(char *addressInSpiffs)
  */
 void SpiffsWrite(char *addressInSpiffs, char *data)
 {
-    if (SpiffsExistenceCheck(addressInSpiffs) == 0)
+    if (SpiffsExistenceCheck(addressInSpiffs) == false)
     {
         ESP_LOGI(TAG, "Opening file for writing");
         FILE *file = fopen(addressInSpiffs, "w");

--- a/components/nvsFlash/include/SpiffsManger.h
+++ b/components/nvsFlash/include/SpiffsManger.h
@@ -62,7 +62,7 @@ void SaveFileInSpiffsWithTxtFormat(char *addressInSpiffs, char *key, char *value
  *@param[out] ... The variable arguments to store the retrieved values. The last argument must be NULL.
  *@return Returns true if the file is successfully read and key-value pairs are retrieved, and false otherwise.
  */
-void ReadTxtFileFromSpiffs(char *addressInSpiffs, char *key, char *value, ...);
+bool ReadTxtFileFromSpiffs(char *addressInSpiffs, char *key, char *value, ...);
 
 /**
  *@brief Check if a file exists in the SPIFFS file system.

--- a/main/main.c
+++ b/main/main.c
@@ -7,7 +7,6 @@
 #include "freertos/task.h"
 // ****************************** GLobal Variables ****************************** //
 QueueHandle_t BufQueue1 = NULL;
-SemaphoreHandle_t HttpsResponseReadySemaphore = NULL;
 
 // ****************************** GLobal Functions ****************************** //
 void CallbackTest(char *buffer)
@@ -30,7 +29,6 @@ void app_main(void)
     SpotifyInterfaceHandler_t SpotifyInterfaceHandler;
 
     SpotifyInterfaceHandler.HttpsBufQueue = &BufQueue1;
-    SpotifyInterfaceHandler.HttpsResponseReadySemaphore = &HttpsResponseReadySemaphore;
     SpotifyInterfaceHandler.IsSpotifyAuthorizedSemaphore = &IsSpotifyAuthorizedSemaphore;
     SpotifyInterfaceHandler.ConfigAddressInSpiffs = SpotifyConfigAddressInSpiffs;
     Spotify_TaskInit(&SpotifyInterfaceHandler);

--- a/main/main.c
+++ b/main/main.c
@@ -32,7 +32,6 @@ void app_main(void)
     SpotifyInterfaceHandler.HttpsBufQueue = &BufQueue1;
     SpotifyInterfaceHandler.HttpsResponseReadySemaphore = &HttpsResponseReadySemaphore;
     SpotifyInterfaceHandler.IsSpotifyAuthorizedSemaphore = &IsSpotifyAuthorizedSemaphore;
-    SpotifyInterfaceHandler.WorkWithStorageInSpotifyComponentSemaphore = &WorkWithStorageInSpotifyComponentSemaphore;
     SpotifyInterfaceHandler.ConfigAddressInSpiffs = SpotifyConfigAddressInSpiffs;
     Spotify_TaskInit(&SpotifyInterfaceHandler);
     // after this semaphore you can use playback command function in every where !


### PR DESCRIPTION
This PR optimises code by improving the SPIFF API call in SpotifyInterface component.
- No semaphore needed any more to tell Spotify that refresh token is already stored in NVS
- JSon parse related functions removed from SPIFF component
- The Spotify state machine now has one less state
- Some minor improvment in SPIFF components